### PR TITLE
Fix package name in RVIZ launch file

### DIFF
--- a/main/launch/main.launch
+++ b/main/launch/main.launch
@@ -59,7 +59,7 @@
   </node>
 
   <!--RVIZ-->
-  <node pkg="rviz" type="rviz" name="rviz" args="-d /home/robond/catkin_ws/src/RoboND-EKFLab/EKFLab.rviz"/>
+  <node pkg="rviz" type="rviz" name="rviz" args="-d /home/robond/catkin_ws/src/robot_pose_ekf/EKFLab.rviz"/>
 
 
   <!--Turtlebot Teleop-->


### PR DESCRIPTION
The package name containing the robot setup should be called "robot_pose_ekf"